### PR TITLE
Merge from 2.7 link field to improve the new Link Field

### DIFF
--- a/classes/fields/link.php
+++ b/classes/fields/link.php
@@ -329,15 +329,16 @@ class PodsField_Link extends PodsField_Website {
 	/**
 	 * Init the editor needed for WP Link modal to work
 	 */
-	public function init_link_editor() {
+	public function validate_link_modal() {
 
 		static $init;
 
 		if ( empty( $init ) ) {
 			if ( ! did_action( 'wp_enqueue_editor' ) ) {
-				echo '<div style="display:none">';
-				wp_editor( '', 'pods-link-editor-hidden' );
-				echo '</div>';
+				//echo '<div style="display:none">';
+				//wp_editor( '', 'pods-link-editor-hidden' );
+				//echo '</div>';
+				add_action( 'shutdown', array( $this, 'add_link_modal' ) );
 			}
 		}
 
@@ -345,4 +346,18 @@ class PodsField_Link extends PodsField_Website {
 
 	}
 
+	/**
+	 * Echo the link modal code
+	 */
+	public function add_link_modal() {
+
+		if ( ! class_exists( '_WP_Editors', false ) && file_exists( ABSPATH . WPINC . '/class-wp-editor.php' ) ) {
+			require_once( ABSPATH . WPINC . '/class-wp-editor.php' );
+
+			if ( method_exists( '_WP_Editors', 'wp_link_dialog' ) ) {
+				_WP_Editors::wp_link_dialog();
+			}
+		}
+	
+	}
 }

--- a/ui/fields/link.php
+++ b/ui/fields/link.php
@@ -1,9 +1,11 @@
 <?php
 
 wp_enqueue_script( 'wplink' );
+wp_enqueue_style( 'editor-buttons' );
+
 wp_enqueue_script( 'pods-link-picker', PODS_URL . 'ui/js/pods-link-picker.js', array( 'jquery' ), '1.0.0' );
 
-PodsForm::field_method( 'link', 'init_link_editor' );
+PodsForm::field_method( 'link', 'validate_link_modal' );
 
 $url_attributes = array();
 $url_type = 'text';
@@ -38,7 +40,6 @@ if (isset($value['target']) && $value['target'] == '_blank') {
 }
 $target_name = $name.'[target]';
 $target_attributes = PodsForm::merge_attributes( $target_attributes, $target_name, $form_field_type, $options );
-
 ?>
 
 <div class="pods-link-options">

--- a/ui/js/pods-link-picker.js
+++ b/ui/js/pods-link-picker.js
@@ -3,66 +3,96 @@
 jQuery(document).ready(function($){
 	
 	// Variable to store the active link picker field
-	var activeLinkPicker;
-	
-	// Open wpLink modal
-	$('body').on('click', '.pods-field .podsLinkPopup', function (e) {
-		activeLinkPicker = $(this).parents('.pods-link-options');
-		$('body').addClass('modal-open-pods-field-link');
-		wpActiveEditor = true;
+	var pods_active_link_picker;
 
-		// Open modal in the dummy textarea
-		wpLink.open( 'pods-link-editor-hidden', activeLinkPicker.find('.linkPickerUrl'), activeLinkPicker.find('.linkPickerText'), $('#pods-link-editor-hidden') );
+	var pods_link_picker = {
 
-		$('#wp-link #wp-link-url').val(activeLinkPicker.find('.linkPickerUrl').val());
-		$('#wp-link #wp-link-text').val(activeLinkPicker.find('.linkPickerText').val());
-		if (activeLinkPicker.find('.linkPickerTarget').is(':checked')) {
-			$('#wp-link #wp-link-target').prop('checked', true);
-		} else {
-			$('#wp-link #wp-link-target').prop('checked', false);
-		}
-		return false;
-	});
-	
-	// Save changes in the selected field
-	$('body').on('click', '#wp-link-submit', function(event) {
-		if ($('body').hasClass('modal-open-pods-field-link')) {
-			//get the href attribute and add to a textfield, or use as you see fit
-			//the links attributes (href, target) are stored in an object, which can be access via  wpLink.getAttrs()
-			var linkAtts = wpLink.getAttrs();
-			if (linkAtts.href != '') {
-				activeLinkPicker.find('.linkPickerUrl').val(linkAtts.href);
-			}
-			//get the target attribute
-			if (linkAtts.target == '_blank') {
-				activeLinkPicker.find('.linkPickerTarget').prop('checked', true);
-			} else {
-				activeLinkPicker.find('.linkPickerTarget').prop('checked', false);
-			}
-			//get the text attribute
-			var linkText = $('#wp-link #wp-link-text').val();
-			if (linkText != '') {
-				activeLinkPicker.find('.linkPickerText').val(linkText);
-			}
-		}
-		$('body').removeClass('modal-open-pods-field-link');
-		wpLink.textarea = $('body'); //to close the link dialogue, it is again expecting an wp_editor instance, so you need to give it something to set focus back to. In this case, I'm using body, but the textfield with the URL would be fine
-		wpLink.close();//close the dialogue
-		//trap any events
-		event.preventDefault ? event.preventDefault() : event.returnValue = false;
-		event.stopPropagation();
-		return false;
-	});
-	
-	// Close modal without any changes
-	$('body').on('click', '#wp-link-cancel, #wp-link-close', function(event) {
-		$('body').removeClass('modal-open-pods-field-link');
-		wpLink.textarea = $('body');
-		wpLink.close();
-		event.preventDefault ? event.preventDefault() : event.returnValue = false;
-		event.stopPropagation();
-		return false;
-	});	
-	
+		init: function() {
+			
+			// Open wpLink modal
+			$('body').on('click', '.pods-field .podsLinkPopup', function (e) {
+				pods_active_link_picker = $(this).parents('.pods-link-options');
+				$('body').addClass('modal-open-pods-field-link');
+
+				var url_elem = pods_active_link_picker.find('.linkPickerUrl');
+				var text_elem = pods_active_link_picker.find('.linkPickerText');
+				var target_elem = pods_active_link_picker.find('.linkPickerTarget');
+
+		        // save any existing default initialization
+		        wplink_defaults = wpLink.setDefaultValues;
+
+				wpLink.setDefaultValues = function() {
+					$('#wp-link-wrap #wp-link-url').val( url_elem.val() );
+					$('#wp-link-wrap #wp-link-text').val( text_elem.val() );
+					if ( target_elem.is(':checked') ) {
+						$('#wp-link-wrap #wp-link-target').prop('checked', true);
+					} else {
+						$('#wp-link-wrap #wp-link-target').prop('checked', false);
+					}
+				};
+
+				// Open modal in the dummy textarea
+				wpLink.open( 'pods-link-editor-hidden' );
+
+				return false;
+			});
+			
+			// Save changes in the selected field
+			$('body').on('click', '#wp-link-submit', function(event) {
+				if ($('body').hasClass('modal-open-pods-field-link')) {
+					//get the href attribute and add to a textfield, or use as you see fit
+					//the links attributes (href, target) are stored in an object, which can be access via  wpLink.getAttrs()
+					var linkAtts = wpLink.getAttrs();
+					if (linkAtts.href != '') {
+						pods_active_link_picker.find('.linkPickerUrl').val(linkAtts.href);
+					}
+					//get the target attribute
+					if (linkAtts.target == '_blank') {
+						pods_active_link_picker.find('.linkPickerTarget').prop('checked', true);
+					} else {
+						pods_active_link_picker.find('.linkPickerTarget').prop('checked', false);
+					}
+					//get the text attribute
+					var linkText = $('#wp-link-wrap #wp-link-text').val();
+					if (linkText != '') {
+						pods_active_link_picker.find('.linkPickerText').val(linkText);
+					}
+				}
+				$('body').removeClass('modal-open-pods-field-link');
+				pods_link_picker.reset_wplink();
+				//trap any events
+				event.preventDefault ? event.preventDefault() : event.returnValue = false;
+				event.stopPropagation();
+
+				return false;
+			});
+			
+			// Close modal without any changes
+			$('body').on('click', '#wp-link-cancel, #wp-link-close', function(event) {
+
+				pods_link_picker.reset_wplink();
+				event.preventDefault ? event.preventDefault() : event.returnValue = false;
+				event.stopPropagation();
+
+				return false;
+			});	
+
+		},
+	    reset_wplink: function() {
+	    	$('body').removeClass('modal-open-pods-field-link');
+	        wpLink.textarea = $('body'); // to close the link dialogue, it is again expecting an wp_editor instance, so you need to give it something to set focus back to. In this case, I'm using body, but the textfield with the URL would be fine
+	        wpLink.close();// close the dialogue
+
+	        // restore wplink default initialization
+	        wpLink.setDefaultValues = wplink_defaults;
+	    }
+	};
+
+	// Validate that we have the right resourses
+	if ( typeof wpLink != 'undefined' && $('#wp-link-wrap').length ) {
+		pods_link_picker.init();
+	} else {
+		$('.pods-field .podsLinkPopup').hide();
+	}
 });
 


### PR DESCRIPTION
Stop using wp_editor fallback -> Instead: include and use the _WP_Editors class to echo the modal code.

Change JS to an object + validate existence of the link modal
If the link modal doesn't exist: hide the option to open one
